### PR TITLE
Update docker-api to v1.28.0 for remote API compatibility

### DIFF
--- a/docker_tools.gemspec
+++ b/docker_tools.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency "bundler", "~> 1.3"
   spec.add_dependency "rake"
-  spec.add_dependency "docker-api", "= 1.21.0"
+  spec.add_dependency "docker-api", "= 1.28.0"
   spec.add_dependency "erubis"
   spec.add_dependency "json"
 end

--- a/lib/docker_tools/dependency.rb
+++ b/lib/docker_tools/dependency.rb
@@ -19,6 +19,7 @@ module DockerTools
       image = DockerTools::Image.new(@name, @registry, @tag)
       begin
         image.pull
+        throw "Cannot find image" if image.image.nil?
       rescue
         puts "Falling back to image #{@registry}/#{@name}:#{@fallback_tag}"
         image = DockerTools::Image.new(@name, @registry, @fallback_tag)

--- a/lib/docker_tools/version.rb
+++ b/lib/docker_tools/version.rb
@@ -1,3 +1,3 @@
 module DockerTools
-  VERSION = "0.0.22"
+  VERSION = "0.0.23"
 end


### PR DESCRIPTION
Something has changed with the docker API.
`image.pull` doesn't result in an error if there is no image found, it just returns nil and the fallback doesn't happen.
Also, `docker-api` updated to match some of these changes in v1.25.0 - using a version before that, even fixing the fallback issue, throws this:

```
/Users/catherine/.gems/gems/docker-api-1.21.0/lib/docker/base.rb:16:in `initialize': Must have id, got: {"id"=>nil, :headers=>{"X-Registry-Auth"=>"eyJ1c2VybmFtZSI6ImFjY2VzcyIsInBhc3N3b3JkIjoic3A2RFU4c0ZycWNUeDdRVjZBeEtFOWVpUkNCTWtaIiwiZW1haWwiOiJkZXZlbG9wbWVudEBpbnRlbnRocS5jb20ifQ=="}} (Docker::Error::ArgumentError)
```

Adding an explicit check for a nil image in the fallback, and updating to any version >=1.25.0 fixes this. Updating to latest cos why not.
