### PR TITLE
Remove hardcoded Docker endpoint and bump docker-api version.

### DIFF
--- a/docker_tools.gemspec
+++ b/docker_tools.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency "bundler", "~> 1.3"
   spec.add_dependency "rake"
-  spec.add_dependency "docker-api", "= 1.21.0"
+  spec.add_dependency "docker-api", "= 1.29.0"
   spec.add_dependency "erubis"
   spec.add_dependency "json"
 end

--- a/lib/docker_tools.rb
+++ b/lib/docker_tools.rb
@@ -7,9 +7,6 @@ require "docker_tools/util"
 require "docker"
 
 module DockerTools
-  #Default the docker url to docker http service
-  Docker.url = 'http://localhost:4243'
-
   def default_dependency_fallback_tag
     'latest'
   end


### PR DESCRIPTION
The `docker-api` is capable of auto-detecting many more types of Docker
endpoints than just the 4243 port so we should allow people to use
sockets and other interesting mechanisms and not hardcode it.
