### PR TITLE
Update Docker API, remove `Docker.url` hardcoding, fix bugs

### DIFF
--- a/docker_tools.gemspec
+++ b/docker_tools.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency "bundler", "~> 1.3"
   spec.add_dependency "rake"
-  spec.add_dependency "docker-api", "= 1.21.0"
+  spec.add_dependency "docker-api", "= 1.32.1"
   spec.add_dependency "erubis"
   spec.add_dependency "json"
 end

--- a/lib/docker_tools.rb
+++ b/lib/docker_tools.rb
@@ -7,9 +7,6 @@ require "docker_tools/util"
 require "docker"
 
 module DockerTools
-  #Default the docker url to docker http service
-  Docker.url = 'http://localhost:4243'
-
   def default_dependency_fallback_tag
     'latest'
   end

--- a/lib/docker_tools/image.rb
+++ b/lib/docker_tools/image.rb
@@ -38,7 +38,7 @@ module DockerTools
         dockerfile_path = "#{@dir}/Dockerfile"
         dockerfile_contents = dockerfile(@name, registry, dependency_tag, template_vars)
         File.open(dockerfile_path, 'w') { | file | file.write(dockerfile_contents) }
-        @image = Docker::Image.build_from_dir(@dir, { 'rm' => rm, 'nocache' => no_cache }) do | chunk | 
+        @image = Docker::Image.build_from_dir(@dir, { 'rm' => rm, 'nocache' => no_cache }) do | chunk |
           DockerTools::Util.parse_output(chunk) do | output |
             if output.kind_of?(Hash)
               if output.has_key?('error')
@@ -109,7 +109,7 @@ module DockerTools
     def lookup_image
       images = Docker::Image.all
       images.each do | image |
-        if image.info['RepoTags'].include?(@full_name)
+        if (image.info['RepoTags'] || []).include?(@full_name)
           return image
         end
       end


### PR DESCRIPTION
* Update `docker-api` to `1.32.1`.
* The `docker-api` is capable of auto-detecting many more types of Docker endpoints than just the `4243` port so we should allow people to use sockets and other interesting mechanisms and not hardcode it.
* Fixing bug where empty tags now come back as `nil` instead of an empty list.