### PR TITLE
Handle cases where pulling fails silently.

### DIFF
--- a/lib/docker_tools/image.rb
+++ b/lib/docker_tools/image.rb
@@ -26,7 +26,9 @@ module DockerTools
     def pull
       puts "Pulling image #{@image_name}"
       Docker::Image.create('fromImage' => @image_name, 'tag' => @tag)
-      @image = lookup_image
+      @image = lookup_image.tap do |image|
+        raise "Failed to pull image '#{image_name}' with tag '#{@tag}'." if image.nil?
+      end
     end
 
     def build(registry: @registry, tag: @tag, method: 'image', distro: 'precise', fallback_tag: DockerTools.dependency_fallback_tag, no_pull: DockerTools.no_pull, template_vars: {}, rm: false, no_cache: false)


### PR DESCRIPTION
Sometimes, on various versions of Docker, the pull fails silently. The
actual image create does seemingly nothing and throws no exception, and
our subsequent attempt to check the image is locally returns `nil`. Up
until now, we never guarded against this `nil` properly. Now we do so
within the `pull` so that no matter how it failed, if after `pull`ing we
couldn't find the image, we raise an exception.